### PR TITLE
针对httpx>=0.28.0的情况，使SSL套件支持https://multimedia.nt.qq.com.cn图床

### DIFF
--- a/nonebot_plugin_randpic/__init__.py
+++ b/nonebot_plugin_randpic/__init__.py
@@ -1,5 +1,5 @@
 from httpx import AsyncClient
-
+import ssl
 from nonebot.adapters.onebot.v11 import MessageSegment, Message, Event, GroupMessageEvent
 from nonebot.adapters.onebot.v11 import GROUP, GROUP_ADMIN, GROUP_OWNER
 from nonebot.plugin import on_fullmatch
@@ -158,16 +158,18 @@ async def add_pic(args: str = Fullmatch(), pic_list: Message = Arg('pic')):
     for pic_name in pic_list:
         if pic_name.type != 'image':
             await add.send(pic_name + MessageSegment.text("\n输入格式有误，请重新触发指令！"), at_sender=True)
-            continue
+            continue  
         pic_url = pic_name.data['url']
 
-        async with AsyncClient() as client:
+        ssl_context = ssl.create_default_context()
+        ssl_context.set_ciphers("DEFAULT")
+        async with AsyncClient(verify=ssl_context) as client:  
             resp = await client.get(pic_url, timeout=5.0)
 
         try:
-            resp.raise_for_status()
+            resp.raise_for_status()    
         except Exception as e:
-            logger.warning(e)
+            logger.warning(e)  
             await add.send(
                 pic_name +
                 MessageSegment.text('\n保存出错了，这张请重试')


### PR DESCRIPTION
参考https://github.com/LagrangeDev/Lagrange.Core/issues/315，https://github.com/Moemu/MuiceBot/pull/4/files