### PR TITLE
针对httpx>=0.28.0的情况，增添SSL套件以正常获取 https://multimedia.nt.qq.com.cn 图床内容

### DIFF
--- a/nonebot_plugin_randpic/__init__.py
+++ b/nonebot_plugin_randpic/__init__.py
@@ -1,5 +1,5 @@
 from httpx import AsyncClient
-
+import ssl
 from nonebot.adapters.onebot.v11 import MessageSegment, Message, Event, GroupMessageEvent
 from nonebot.adapters.onebot.v11 import GROUP, GROUP_ADMIN, GROUP_OWNER
 from nonebot.plugin import on_fullmatch
@@ -161,7 +161,9 @@ async def add_pic(args: str = Fullmatch(), pic_list: Message = Arg('pic')):
             continue
         pic_url = pic_name.data['url']
 
-        async with AsyncClient() as client:
+        ssl_context = ssl.create_default_context()
+        ssl_context.set_ciphers("DEFAULT")
+        async with AsyncClient(verify=ssl_context) as client:
             resp = await client.get(pic_url, timeout=5.0)
 
         try:


### PR DESCRIPTION
目前在httpx>=0.28.0的情况下，会产生问题`httpx.ConnectError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] ssl/tls alert handshake failure (_ssl.c:1007)`。 解决方法参考https://github.com/LagrangeDev/Lagrange.Core/issues/315 https://github.com/Moemu/MuiceBot/pull/4/files